### PR TITLE
update steady timer PR

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -22,7 +22,7 @@ list(GET roscpp_VERSION_LIST 2 roscpp_VERSION_PATCH)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ros/common.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros/common.h)
 
-find_package(Boost REQUIRED COMPONENTS signals filesystem system chrono)
+find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
 
 include_directories(include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 

--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -1487,7 +1487,7 @@ if (service)  // Enter if advertised service is valid
    */
   template<class T>
   SteadyTimer createSteadyTimer(WallDuration period, void(T::*callback)(const SteadyTimerEvent&), T* obj,
-                                      bool oneshot = false, bool autostart = true) const
+                                bool oneshot = false, bool autostart = true) const
   {
     return createSteadyTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
   }
@@ -1509,8 +1509,8 @@ if (service)  // Enter if advertised service is valid
    */
   template<class T>
   SteadyTimer createSteadyTimer(WallDuration period, void(T::*callback)(const SteadyTimerEvent&),
-                                      const boost::shared_ptr<T>& obj,
-                                      bool oneshot = false, bool autostart = true) const
+                                const boost::shared_ptr<T>& obj,
+                                bool oneshot = false, bool autostart = true) const
   {
     SteadyTimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
     ops.tracked_object = obj;
@@ -1532,7 +1532,7 @@ if (service)  // Enter if advertised service is valid
    * \param oneshot If true, this timer will only fire once
    */
   SteadyTimer createSteadyTimer(WallDuration period, const SteadyTimerCallback& callback,
-                                      bool oneshot = false, bool autostart = true) const;
+                                bool oneshot = false, bool autostart = true) const;
 
   /**
    * \brief Create a timer which will call a callback at the specified rate, using wall time to determine

--- a/clients/roscpp/include/ros/steady_timer_options.h
+++ b/clients/roscpp/include/ros/steady_timer_options.h
@@ -52,7 +52,7 @@ struct ROSCPP_DECL SteadyTimerOptions
    * \param
    */
   SteadyTimerOptions(WallDuration _period, const SteadyTimerCallback& _callback, CallbackQueueInterface* _queue,
-                   bool oneshot = false, bool autostart = true)
+                     bool oneshot = false, bool autostart = true)
   : period(_period)
   , callback(_callback)
   , callback_queue(_queue)

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -576,7 +576,7 @@ void TimerManager<T, D, E>::threadFunc()
       {
         // On system time we can simply sleep for the rest of the wait time, since anything else requiring processing will
         // signal the condition variable
-        int32_t remaining_time = std::max((int32_t) ((sleep_end - current).toSec() * 1000.0f), 1);
+        int32_t remaining_time = std::max((int32_t)((sleep_end - current).toSec() * 1000.0f), 1);
         timers_cond_.timed_wait(lock, boost::posix_time::milliseconds(remaining_time));
       }
     }

--- a/clients/roscpp/package.xml
+++ b/clients/roscpp/package.xml
@@ -31,7 +31,7 @@
   <build_depend version_gte="0.3.17">roscpp_traits</build_depend>
   <build_depend version_gte="1.10.3">rosgraph_msgs</build_depend>
   <build_depend>roslang</build_depend>
-  <build_depend>rostime</build_depend>
+  <build_depend version_gte="0.6.4">rostime</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>xmlrpcpp</build_depend>
 
@@ -41,7 +41,7 @@
   <run_depend>roscpp_serialization</run_depend>
   <run_depend version_gte="0.3.17">roscpp_traits</run_depend>
   <run_depend version_gte="1.10.3">rosgraph_msgs</run_depend>
-  <run_depend>rostime</run_depend>
+  <run_depend version_gte="0.6.4">rostime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>xmlrpcpp</run_depend>
 </package>

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -452,7 +452,7 @@ WallTimer NodeHandle::createWallTimer(WallTimerOptions& ops) const
 }
 
 SteadyTimer NodeHandle::createSteadyTimer(WallDuration period, const SteadyTimerCallback& callback,
-                                                bool oneshot, bool autostart) const
+                                          bool oneshot, bool autostart) const
 {
   SteadyTimerOptions ops;
   ops.period = period;


### PR DESCRIPTION
The important change is the minimum version for the dependency on rostime to ensure the version contains `SteadyTime`.

The other changes are mostly spaces.